### PR TITLE
ignore eol versions for go 1.19 as we require that in wolfi for boots…

### DIFF
--- a/version_streams/go.yaml
+++ b/version_streams/go.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   endOfLife:
     identifier: go
+  ignoreEolVersions:
+  - "1.19"
   versionStreamFormat: ${{name}}-${{versions.major}}.${{versions.minor}}
 status:
   eolVersions:


### PR DESCRIPTION
…trapping