### PR TITLE
adding prometheus version streams

### DIFF
--- a/version_streams/prometheus.yaml
+++ b/version_streams/prometheus.yaml
@@ -1,0 +1,8 @@
+apiVersion: versions.wolfi.dev/v1
+kind: VersionStream
+metadata:
+  name: prometheus
+spec:
+  endOfLife:
+    identifier: prometheus
+  versionStreamFormat: ${{name}}-${{versions.major}}.${{versions.minor}}


### PR DESCRIPTION
Adding the version stream for prometheus. Reason at: https://github.com/chainguard-dev/image-requests/issues/840